### PR TITLE
feat: :construction: Add docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,28 @@
 services:
+  app:
+    build: .
+    container_name: "widget-server"
+    restart: unless-stopped
+
+    ports: 
+      - "3333:3333"
+    environment:
+    - CLOUDFLARE_ACCOUNT_ID=${CLOUDFLARE_ACCOUNT_ID}
+    - CLOUDFLARE_ACCESS_KEY_ID=${CLOUDFLARE_ACCESS_KEY_ID}
+    - CLOUDFLARE_SECRET_ACCESS_KEY=${CLOUDFLARE_SECRET_ACCESS_KEY}
+    - CLOUDFLARE_BUCKET=${CLOUDFLARE_BUCKET}
+    - CLOUDFLARE_PUBLIC_URL=${CLOUDFLARE_PUBLIC_URL}\
+    - DATABASE_URL=${DATABASE_URL}
+
   pg:
     image: bitnami/postgresql:latest
+    container_name: "widget-pg"
+    restart: unless-stopped
     ports:
       - '5432:5432'
     environment:
-      - POSTGRES_USER=docker
-      - POSTGRES_PASSWORD=docker
-      - POSTGRES_DB=upload
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
     volumes:
       - './docker:/docker-entrypoint-initdb.d'


### PR DESCRIPTION
This commit introduces a `docker-compose.yml` file to facilitate local development and testing. The changes include:

-   Defining a service for the application (`app`) that builds from the current directory.
-   Configuring the `app` service with environment variables for Cloudflare and database access.
-   Defining a service for PostgreSQL (`pg`) using the Bitnami image, including port mapping and environment variables for database credentials.
-   Specifying volumes for PostgreSQL data persistence.