### PR TITLE
feat: :mag: Improve image scanning by exporting image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,8 +59,7 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: |
-            widget-server:test  # Tag local, sem referência ao ECR
+          tags: widget-server:test  # Tag local, sem referência ao ECR
           platforms: linux/amd64
 
       - name: Debug local images after build
@@ -72,7 +71,7 @@ jobs:
         id: run-trivy-scanner
         uses: aquasecurity/trivy-action@0.29.0
         with:
-          image-ref: 'widget-server:test'  # Escaneia a imagem local
+          image-ref: 'widget-server:test'
           format: 'table'
           ignore-unfixed: true
           vuln-type: 'os,library'
@@ -86,8 +85,7 @@ jobs:
           context: .
           push: true
           cache-from: type=gha
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ steps.generate-tags.outputs.sha }}
+          tags: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ steps.generate-tags.outputs.sha }}
           platforms: linux/amd64
 
       - name: Debug ECR images after push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,12 +50,13 @@ jobs:
           SHA=$(echo $GITHUB_SHA | head -c7)
           echo "sha=$SHA" >> $GITHUB_OUTPUT
 
-      - name: Build and export image
+      - name: Build and export image for scanning
         id: build-and-export-image
         uses: docker/build-push-action@v6
         with:
           context: .
-          load: true
+          load: true 
+          push: false  
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,42 +55,42 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          load: true 
-          push: false  
+          load: true
+          push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:test
-          platforms: linux/amd64  # Fixa a plataforma
+            widget-server:test  # Tag local, sem referência ao ECR
+          platforms: linux/amd64
+
+      - name: Debug local images after build
+        run: |
+          echo "Imagens locais após build para escaneamento:"
+          docker images
 
       - name: Run Trivy vulnerability scanner
         id: run-trivy-scanner
         uses: aquasecurity/trivy-action@0.29.0
         with:
-          image-ref: '${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:test'
+          image-ref: 'widget-server:test'  # Escaneia a imagem local
           format: 'table'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
-      - name: Build and push
+      - name: Build and push to ECR
+        id: build-and-push
         if: success()
         uses: docker/build-push-action@v6
         with:
-          cache-from: type=gha
           context: .
           push: true
+          cache-from: type=gha
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ steps.generate-tags.outputs.sha }}
-          platforms: linux/amd64  # Fixa a plataforma
+          platforms: linux/amd64
 
-
-           # - name: Build and push Docker image to AWS ECR
-          #   env:
-          #     ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          #     ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
-          #     IMAGE_TAG: ${{ steps.generate-tags.outputs.sha }}
-          #   id: build-and-push-image
-          #   run: |
-          #     docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          #     docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+      - name: Debug ECR images after push
+        run: |
+          echo "Imagens no ECR após push:"
+          aws ecr describe-images --repository-name ${{ vars.ECR_REPOSITORY }} --region ${{ vars.AWS_REGION }} --query 'imageDetails[*].[imageDigest,imageTags,imagePushedAt,imageSizeInBytes]' --output table

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,17 +12,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+
       - name: Configure Node.js
         id: configure-nodejs
         uses: actions/setup-node@v4
         with:
           node-version: 22
       
-      - name: Install pnpm
-        id: install-pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.6.4
+      -  name: Install pnpm
+         id: install-pnpm
+         uses: pnpm/action-setup@v4
+         with:
+            version: 10.6.4
 
       - name: Install dependencies
         id: install-dependencies
@@ -34,7 +35,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region:  ${{ vars.AWS_REGION }}
 
       - name: Login to AWS ECR
         id: login-ecr
@@ -47,50 +48,48 @@ jobs:
       - name: Generate tag
         id: generate-tags
         run: |
-          SHA=$(echo $GITHUB_SHA | head -c7)
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
+         SHA=$(echo $GITHUB_SHA | head -c7)
+         echo "sha=$SHA" >> $GITHUB_OUTPUT
 
-      - name: Build and export image for scanning
+
+      - name: Build and export image
         id: build-and-export-image
         uses: docker/build-push-action@v6
         with:
           context: .
           load: true
-          push: false
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: widget-server:test
-          platforms: linux/amd64
-
-      - name: Debug local images after build
-        run: |
-          echo "Imagens locais após build para escaneamento:"
-          docker images
+          cache-to: type=gha, mode=max
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:test
 
       - name: Run Trivy vulnerability scanner
         id: run-trivy-scanner
         uses: aquasecurity/trivy-action@0.29.0
         with:
-          image-ref: 'widget-server:test'
-          format: 'table'
-          ignore-unfixed: true
-          vuln   vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+           image-ref: '${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:test'
+           format: 'table'
+           ignore-unfixed: true
+           vuln-type: 'os,library'
+           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
-      - name: Build and push to ECR
-        id: build-and-push
-        if: success()
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          cache-from: type=gha
           context: .
           push: true
-          cache-from: type=gha
-          tags: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ steps.generate-tags.outputs.sha }}
-          platforms: linux/amd64
+          tags: |
+             ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ steps.generate-tags.outputs.sha }}
+        
+      # - name: Build and push Docker image to AWS ECR
+      #   env:
+      #     ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      #     ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+      #     IMAGE_TAG: ${{ steps.generate-tags.outputs.sha }}
+      #   id: build-and-push-image
+      #   run: |
+      #     docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+      #     docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
-      - name: Debug images after push
-        run: |
-          echo "Imagens locais após push:"
-          docker images
-          echo "Imagens no ECR após push:"
-          aws ecr describe-images --repository-name ${{ vars.ECR_REPOSITORY }} --region ${{ vars.AWS_REGION }} --output json
+      

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: widget-server:test  # Tag local, sem referência ao ECR
+          tags: widget-server:test
           platforms: linux/amd64
 
       - name: Debug local images after build
@@ -74,7 +74,7 @@ jobs:
           image-ref: 'widget-server:test'
           format: 'table'
           ignore-unfixed: true
-          vuln-type: 'os,library'
+          vuln   vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
       - name: Build and push to ECR
@@ -88,7 +88,9 @@ jobs:
           tags: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ steps.generate-tags.outputs.sha }}
           platforms: linux/amd64
 
-      - name: Debug ECR images after push
+      - name: Debug images after push
         run: |
+          echo "Imagens locais após push:"
+          docker images
           echo "Imagens no ECR após push:"
-          aws ecr describe-images --repository-name ${{ vars.ECR_REPOSITORY }} --region ${{ vars.AWS_REGION }} --query 'imageDetails[*].[imageDigest,imageTags,imagePushedAt,imageSizeInBytes]' --output table
+          aws ecr describe-images --repository-name ${{ vars.ECR_REPOSITORY }} --region ${{ vars.AWS_REGION }} --output json


### PR DESCRIPTION
This commit modifies the CI workflow to improve the image scanning process. Specifically, it:

-   Changes the `docker/build-push-action` to export the image for scanning instead of pushing it.
-   Sets `push: false` to prevent pushing the image to a registry at this stage.
-   This allows the Trivy vulnerability scanner to analyze the built image more effectively.